### PR TITLE
feat: introduce non-flake compatibility

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+let cfg = config.services.prometheus.exporters.cgroup; in {
+  options.services.prometheus.exporters.cgroup = {
+    enable = lib.mkEnableOption "cgroup-exporter";
+    package = lib.mkPackageOption pkgs "cgroup-exporter" { };
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "[::]";
+      description = "Address to listen on";
+    };
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 13232;
+      description = "Port to listen on";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.cgroup-exporter = {
+      description = "cgroup-exporter";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/cgroup-exporter -listen-address ${cfg.listenAddress}:${toString cfg.port}";
+        Restart = "always";
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,8 @@
+{ buildGoModule }:
+
+buildGoModule {
+  pname = "cgroup-exporter";
+  version = "0.1.0";
+  src = ../.;
+  vendorHash = "sha256-srQcHjMVz9wV96eAX9P9iRtvi7CHqZC+GZSsh+gkrvU=";
+}


### PR DESCRIPTION
nix/*.nix are vanilla Nix expressions that advanced users can shape for their own needs.

The rest is relinked into the flake.nix for good UX for innocent flake users.

I'm still running the tests.