### PR TITLE
fix(warn): use stdenv.hostPlatform.system instead of system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
         imports = [ ./nix/module.nix ];
 
         services.prometheus.exporters.cgroup.package =
-          lib.mkDefault self.packages.${pkgs.system}.default;
+          lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
       };
 
       overlays.default = final: prev: {


### PR DESCRIPTION
The workaround for #15 was getting shabby so I just quickly made this PR.