### PR TITLE
fix: produce valid fs.FS paths when walking root cgroup

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
-	"path/filepath"
+	pathpkg "path"
 	"strconv"
 	"strings"
 
@@ -202,7 +202,7 @@ func FindFilesInLeafDirectories(fsys fs.FS, root string, process func(filePath s
 			if isLeaf {
 				for _, entry := range subDirEntries {
 					if !entry.IsDir() {
-						filePath := fmt.Sprintf("%s/%s", path, entry.Name())
+						filePath := pathpkg.Join(path, entry.Name())
 						if err := process(filePath, entry); err != nil {
 							return err
 						}
@@ -213,7 +213,6 @@ func FindFilesInLeafDirectories(fsys fs.FS, root string, process func(filePath s
 		return nil
 	})
 }
-
 
 // Collect implements prometheus.Collector.
 func (c *cgroupCollector) Collect(m chan<- prometheus.Metric) {
@@ -231,7 +230,7 @@ func (c *cgroupCollector) Collect(m chan<- prometheus.Metric) {
 					return fmt.Errorf("failed to open file %q: %w", path, err)
 				}
 				defer f.Close()
-				if err := col.collect(f, filepath.Dir(path), col.desc, m); err != nil {
+				if err := col.collect(f, pathpkg.Dir(path), col.desc, m); err != nil {
 					slog.Error("failed to collect cgroup", "error", err)
 				}
 			}
@@ -241,7 +240,7 @@ func (c *cgroupCollector) Collect(m chan<- prometheus.Metric) {
 					return fmt.Errorf("failed to open file %q: %w", path, err)
 				}
 				defer f.Close()
-				if err := col.collect(f, filepath.Dir(path), col.descs, m); err != nil {
+				if err := col.collect(f, pathpkg.Dir(path), col.descs, m); err != nil {
 					slog.Error("failed to collect cgroup", "error", err)
 				}
 			}

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -219,6 +219,57 @@ func TestDoesntOpenFilesThatItDoesntHaveDescriptionsFor(t *testing.T) {
 	<-metrics
 }
 
+func TestFindFilesInLeafDirectoriesRoot(t *testing.T) {
+	mapfs := fstest.MapFS{
+		"memory.current": &fstest.MapFile{Data: []byte("1234\n")},
+		"cpu.stat":       &fstest.MapFile{Data: []byte("usage_usec 100\n")},
+	}
+	var paths []string
+	err := FindFilesInLeafDirectories(mapfs, ".", func(filePath string, entry fs.DirEntry) error {
+		paths = append(paths, filePath)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("expected files in root directory")
+	}
+	for _, p := range paths {
+		if !fs.ValidPath(p) {
+			t.Errorf("path %q is not a valid fs.FS path", p)
+		}
+	}
+}
+
+func TestCollectsFromRootCgroup(t *testing.T) {
+	mapfs := fstest.MapFS{
+		"memory.current": &fstest.MapFile{Data: []byte("1234\n")},
+	}
+	c := New(mapfs, ".")
+	metrics := make(chan prometheus.Metric)
+	go func() {
+		defer close(metrics)
+		c.Collect(metrics)
+	}()
+	metric := <-metrics
+	if metric == nil {
+		t.Fatal("expected metric from root cgroup")
+	}
+	dto := new(io_prometheus_client.Metric)
+	if err := metric.Write(dto); err != nil {
+		t.Fatal(err)
+	}
+	if *dto.Gauge.Value != 1234 {
+		t.Errorf("expected 1234 got %f", *dto.Gauge.Value)
+	}
+	for _, l := range dto.Label {
+		if *l.Name == "cgroup" && *l.Value != "." {
+			t.Errorf("expected cgroup label '.' got %q", *l.Value)
+		}
+	}
+}
+
 func TestCanParseRootIOStart(t *testing.T) {
 	iostat := `
 7:7 


### PR DESCRIPTION
I found this bug while adding `cgroup-exporter` to a Containerized env.

`FindFilesInLeafDirectories` constructed file paths with `fmt.Sprintf("%s/%s", path, entry.Name())`, which produces "`./memory.current`" when path is "`.`". This is not a valid `fs.FS` path, causing `os.DirFS` to reject it with "invalid argument".

Use `path.Join` instead, which cleans the "`.`" element and produces `memory.current` — a valid path. This fixes `collection` when running inside a container where the root is the cgroup (i.e. `-cgroup .`).

Also switch from `path/filepath` to `path`, which is the correct package for slash-separated `fs.FS` paths.