### PR TITLE
collector: skip invalid devices in io.stat

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -285,7 +285,15 @@ func (c *cgroupCollector) Collect(m chan<- prometheus.Metric) {
 }
 
 func collectIOStat(f io.Reader, path string, descs map[string]desc, m chan<- prometheus.Metric) error {
+	warnedInvalidDevices := map[string]struct{}{}
 	return visitNestedKeyed(f, func(n string) (kvVisitor, error) {
+		if !isBlockDeviceID(n) {
+			if _, warned := warnedInvalidDevices[n]; !warned {
+				slog.Warn("skipping io.stat entry with invalid device", "device", n, "cgroup", path)
+				warnedInvalidDevices[n] = struct{}{}
+			}
+			return nil, nil
+		}
 		device := n
 		return func(k, v string) error {
 			desc, ok := descs[k]
@@ -300,6 +308,22 @@ func collectIOStat(f io.Reader, path string, descs map[string]desc, m chan<- pro
 			return nil
 		}, nil
 	})
+}
+
+func isBlockDeviceID(device string) bool {
+	major, minor, ok := strings.Cut(device, ":")
+	if !ok || major == "" || minor == "" {
+		return false
+	}
+
+	if _, err := strconv.ParseUint(major, 10, 32); err != nil {
+		return false
+	}
+	if _, err := strconv.ParseUint(minor, 10, 32); err != nil {
+		return false
+	}
+
+	return true
 }
 
 func collectNumaStat(f io.Reader, path string, descs map[string]desc, m chan<- prometheus.Metric) error {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,9 +1,11 @@
 package collector
 
 import (
+	"bytes"
 	"embed"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"regexp"
 	"strings"
 	"testing"
@@ -334,6 +336,55 @@ func TestCanParseRootIOStart(t *testing.T) {
 		}
 	}
 
+}
+
+func TestIOStatSkipsInvalidDevices(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	iostat := `(unknown) rbytes=0 wbytes=0 rios=6 wios=0 dbytes=0 dios=0
+259:3 rbytes=241664 wbytes=0 rios=6 wios=0 dbytes=0 dios=0
+(unknown) rbytes=0 wbytes=0 rios=13 wios=0 dbytes=0 dios=0
+259:2 rbytes=581632 wbytes=0 rios=13 wios=0 dbytes=0 dios=0
+`
+	c := New(fstest.MapFS{}, "").(*cgroupCollector)
+	ms := make(chan prometheus.Metric)
+	go func() {
+		defer close(ms)
+		if err := collectIOStat(strings.NewReader(iostat), "init.scope", c.multipleCollectors["io.stat"].descs, ms); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	var metricCount int
+	for m := range ms {
+		metricCount++
+		dto := new(io_prometheus_client.Metric)
+		if err := m.Write(dto); err != nil {
+			t.Fatal(err)
+		}
+		for _, l := range dto.Label {
+			if *l.Name == "device" && *l.Value == "(unknown)" {
+				t.Fatal("unexpected metric emitted for invalid device")
+			}
+		}
+	}
+
+	if metricCount != 12 {
+		t.Fatalf("expected 12 metrics from 2 valid devices, got %d", metricCount)
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "skipping io.stat entry with invalid device") {
+		t.Fatalf("expected warning log, got %q", logOutput)
+	}
+	if strings.Count(logOutput, "device=(unknown)") != 1 {
+		t.Fatalf("expected one warning for invalid device, got %q", logOutput)
+	}
 }
 
 func TestCanParseNumaStat(t *testing.T) {


### PR DESCRIPTION
  ## Summary

  Some cgroup `io.stat` files can contain entries like `(unknown)` instead of a
  valid `major:minor` block device ID. This change makes the collector ignore
  those entries instead of treating them like real devices.

  ## What changed

  - validate `io.stat` device keys before exporting metrics
  - skip invalid entries and log a warning once per device per cgroup
  - add a test covering mixed valid and invalid `io.stat` input

  ## Why

We had this issue come up for duplicated prom metrics

```
[root@backend23 (mainnet):~]# curl localhost:9809/metrics -s | head
An error has occurred while serving metrics:

222 error(s) occurred:
* collected metric "cgroup_io_read_bytes_total" { label:{name:"cgroup"  value:"dev-hugepages.mount"}  label:{name:"device"  value:"(unknown)"}  counter:{value:0}} was collected before with the same name and label values
* collected metric "cgroup_io_write_bytes_total" { label:{name:"cgroup"  value:"dev-hugepages.mount"}  label:{name:"device"  value:"(unknown)"}  counter:{value:0}} was collected before with the same name and label values
```

Seems it's a nuance with zfs https://github.com/openzfs/zfs/issues/13662

I'm not sure but I think this (unknown) is just excessive layer created by zfs for internal "tank" abstraction

```
cat "$CG/io.stat"
(unknown) rbytes=0 wbytes=0 rios=6 wios=0 dbytes=0 dios=0
259:3 rbytes=241664 wbytes=0 rios=6 wios=0 dbytes=0 dios=0
(unknown) rbytes=0 wbytes=0 rios=13 wios=0 dbytes=0 dios=0
259:2 rbytes=581632 wbytes=0 rios=13 wios=0 dbytes=0 dios=0
(unknown) rbytes=0 wbytes=0 rios=6 wios=0 dbytes=0 dios=0
259:3 rbytes=24576 wbytes=0 rios=6 wios=0 dbytes=0 dios=0
(unknown) rbytes=0 wbytes=0 rios=11 wios=0 dbytes=0 dios=0
259:2 rbytes=49152 wbytes=0 rios=11 wios=0 dbytes=0 dios=0
```

In any case, there's warning printed, but it seems to me to be safe ignore in this case (we don't have another option atm than to ignore it).