### PR TITLE
feat: add best-effort cgroup open fd metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Metrics supported are:
     - `memory.stat` gives page faults, cache, swap, etc
     - `cpu.stat` gives number of times the CPU was throttled, time spent in different states, etc
     - `memory.numa_stat` gives per-NUMA node memory statistics
+* Process accounting derived from procfs
+    - `cgroup_open_fds_current` counts open file descriptors by summing `/proc/<pid>/fd` for the PIDs listed in each cgroup's `cgroup.procs`
 
 
 Systemd dropped support for the legacy cgroup hierarchy in version 256.
@@ -42,4 +44,3 @@ baggage of supporting both cgroupv1 and cgroupv2, and is missing a lot of metric
 
 [`treydock/cgroup_exporter`](https://github.com/treydock/cgroup_exporter) also comes with the
 baggage of supporting both cgroupv1 and cgroupv2, and is missing a lot of metrics.
-

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -9,13 +10,16 @@ import (
 	pathpkg "path"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type cgroupCollector struct {
 	fs                 fs.FS
+	procfs             fs.FS
 	glob               string
+	openFDsDesc        *prometheus.Desc
 	singleCollectors   map[string]collector
 	multipleCollectors map[string]multipleCollector
 }
@@ -38,17 +42,25 @@ type multipleCollector struct {
 type collectFunc func(f io.Reader, path string, desc *prometheus.Desc, m chan<- prometheus.Metric) error
 type collectMultipleFunc func(f io.Reader, path string, desc map[string]desc, m chan<- prometheus.Metric) error
 
+var errSkipMetric = errors.New("skip metric")
+
 func microSecondsToSeconds(microseconds float64) float64 {
 	return microseconds / 1e6
 }
 
 func New(fs fs.FS, glob string) prometheus.Collector {
+	return NewWithProcfs(fs, nil, glob)
+}
+
+func NewWithProcfs(fs fs.FS, procfs fs.FS, glob string) prometheus.Collector {
 	if glob == "" {
 		glob = "*"
 	}
 	return &cgroupCollector{
-		fs:   fs,
-		glob: glob,
+		fs:          fs,
+		procfs:      procfs,
+		glob:        glob,
+		openFDsDesc: prometheus.NewDesc("cgroup_open_fds_current", "Number of open file descriptors held by processes currently in the cgroup.", []string{"cgroup"}, nil),
 		singleCollectors: map[string]collector{
 			"memory.min":     {desc: prometheus.NewDesc("cgroup_memory_min_bytes", "", []string{"cgroup"}, nil), collect: collectSingleValue(prometheus.GaugeValue)},
 			"memory.low":     {desc: prometheus.NewDesc("cgroup_memory_low_bytes", "", []string{"cgroup"}, nil), collect: collectSingleValue(prometheus.GaugeValue)},
@@ -273,6 +285,20 @@ func (c *cgroupCollector) Collect(m chan<- prometheus.Metric) {
 				}
 			}
 
+			if name == "cgroup.procs" && c.procfs != nil {
+				f, err := c.fs.Open(path)
+				if err != nil {
+					return fmt.Errorf("failed to open file %q: %w", path, err)
+				}
+				defer f.Close()
+				if err := c.collectOpenFDs(f, pathpkg.Dir(path), m); err != nil {
+					if errors.Is(err, errSkipMetric) {
+						return nil
+					}
+					slog.Error("failed to collect cgroup open file descriptors", "error", err, "cgroup", pathpkg.Dir(path))
+				}
+			}
+
 			// TODO: refactor stuff so this is generic
 			if name == "io.stat" {
 			}
@@ -282,6 +308,59 @@ func (c *cgroupCollector) Collect(m chan<- prometheus.Metric) {
 			slog.Error("failed to walk cgroup", "error", err)
 		}
 	}
+}
+
+func (c *cgroupCollector) collectOpenFDs(f io.Reader, path string, m chan<- prometheus.Metric) error {
+	pids, err := readPIDs(f)
+	if err != nil {
+		return err
+	}
+
+	var total float64
+	for _, pid := range pids {
+		fdDir := pathpkg.Join(pid, "fd")
+		entries, err := fs.ReadDir(c.procfs, fdDir)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			if isProcfsAccessError(err) {
+				return errSkipMetric
+			}
+			return fmt.Errorf("read %q: %w", fdDir, err)
+		}
+		total += float64(len(entries))
+	}
+
+	m <- prometheus.MustNewConstMetric(c.openFDsDesc, prometheus.GaugeValue, total, path)
+	return nil
+}
+
+func isProcfsAccessError(err error) bool {
+	return errors.Is(err, fs.ErrPermission) ||
+		errors.Is(err, syscall.EPERM) ||
+		errors.Is(err, syscall.EACCES)
+}
+
+func readPIDs(r io.Reader) ([]string, error) {
+	scanner := bufio.NewScanner(r)
+	seen := make(map[string]struct{})
+	var pids []string
+	for scanner.Scan() {
+		pid := strings.TrimSpace(scanner.Text())
+		if pid == "" {
+			continue
+		}
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		pids = append(pids, pid)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return pids, nil
 }
 
 func collectIOStat(f io.Reader, path string, descs map[string]desc, m chan<- prometheus.Metric) error {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -75,6 +75,105 @@ func TestSkipsMaxMemoryMax(t *testing.T) {
 	}
 }
 
+func TestCollectsOpenFDsFromProcfs(t *testing.T) {
+	cgroupfs := fstest.MapFS{
+		"system.slice/worker.service/cgroup.procs": &fstest.MapFile{Data: []byte("123\n123\n456\n789\n")},
+	}
+	procfs := fstest.MapFS{
+		"123/fd/0": &fstest.MapFile{},
+		"123/fd/1": &fstest.MapFile{},
+		"456/fd/0": &fstest.MapFile{},
+		"456/fd/1": &fstest.MapFile{},
+		"456/fd/2": &fstest.MapFile{},
+	}
+
+	c := NewWithProcfs(cgroupfs, procfs, "")
+	metrics := make(chan prometheus.Metric)
+	go func() {
+		defer close(metrics)
+		c.Collect(metrics)
+	}()
+
+	metric := <-metrics
+	if metric == nil {
+		t.Fatal("expected metric")
+	}
+
+	dto := new(io_prometheus_client.Metric)
+	if err := metric.Write(dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.Gauge == nil || dto.Gauge.Value == nil {
+		t.Fatal("expected gauge metric")
+	}
+	if *dto.Gauge.Value != 5 {
+		t.Fatalf("expected 5 open fds, got %f", *dto.Gauge.Value)
+	}
+
+	var foundCgroup bool
+	for _, l := range dto.Label {
+		if *l.Name == "cgroup" {
+			foundCgroup = true
+			if *l.Value != "system.slice/worker.service" {
+				t.Fatalf("expected cgroup label system.slice/worker.service, got %q", *l.Value)
+			}
+		}
+	}
+	if !foundCgroup {
+		t.Fatal("expected cgroup label")
+	}
+}
+
+func TestReadPIDsDeDuplicatesAndSkipsBlanks(t *testing.T) {
+	pids, err := readPIDs(strings.NewReader("123\n\n123\n456\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"123", "456"}
+	if len(pids) != len(expected) {
+		t.Fatalf("expected %d pids, got %d", len(expected), len(pids))
+	}
+	for i := range expected {
+		if pids[i] != expected[i] {
+			t.Fatalf("expected pid %q at index %d, got %q", expected[i], i, pids[i])
+		}
+	}
+}
+
+type permissionDeniedFS struct{}
+
+func (permissionDeniedFS) Open(name string) (fs.File, error) {
+	return nil, fs.ErrPermission
+}
+
+func TestSkipsOpenFDMetricWhenProcfsIsNotPermitted(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	cgroupfs := fstest.MapFS{
+		"system.slice/worker.service/cgroup.procs": &fstest.MapFile{Data: []byte("123\n")},
+	}
+
+	c := NewWithProcfs(cgroupfs, permissionDeniedFS{}, "")
+	metrics := make(chan prometheus.Metric)
+	go func() {
+		defer close(metrics)
+		c.Collect(metrics)
+	}()
+
+	metric, ok := <-metrics
+	if ok || metric != nil {
+		t.Fatal("expected open fd metric to be skipped when procfs is not permitted")
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("expected no error logs, got %q", logs.String())
+	}
+}
+
 func TestParsesOtherMemory(t *testing.T) {
 	mapfs := fstest.MapFS{
 		"system.slice/memory.min": &fstest.MapFile{Data: []byte("1\n")},

--- a/main.go
+++ b/main.go
@@ -16,8 +16,9 @@ func main() {
 	cgroup := flag.String("cgroup", "", "what cgroup to monitor. Can be a blob. If empty all cgroups are monitored.")
 	flag.Parse()
 	cgroupfs := os.DirFS("/sys/fs/cgroup")
+	procfs := os.DirFS("/proc")
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(collector.New(cgroupfs, *cgroup))
+	registry.MustRegister(collector.NewWithProcfs(cgroupfs, procfs, *cgroup))
 	http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{Registry: registry}))
 	// TODO: cancellation
 	if err := http.ListenAndServe(*addr, nil); err != nil {


### PR DESCRIPTION
This adds `cgroup_open_fds_current`, derived by summing `/proc/<pid>/fd` for the PIDs listed in each cgroup’s cgroup.procs.

This does intentionally break the exporter’s previous pattern of reading only native cgroup files under /sys/fs/cgroup. I think that tradeoff is justified here because cgroup v2 does not expose open FD counts directly, and /proc is the only practical way to answer the question at cgroup scope.

The implementation is deliberately defensive: procfs-backed collection is optional, PID races are tolerated, and permission or access issues in /proc cause the metric to be skipped rather than making scrapes noisy or fragile. So in normal environments we get the extra visibility, and in restricted or unusual environments the exporter keeps behaving safely.