### PR TITLE
prepare 0.3.3

### DIFF
--- a/deploy/daemonset.yaml
+++ b/deploy/daemonset.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: cgroup-exporter
-          image: ghcr.io/arianvp/cgroup-exporter:0.3.1-amd64
+          image: ghcr.io/arianvp/cgroup-exporter:0.3.3-amd64
           ports:
             - containerPort: 13232
           volumeMounts:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "cgroup-exporter";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = lib.fileset.toSource {
     root = ../.;


### PR DESCRIPTION
0.3.2 was wrongly tagged as I didn't update the deploy example The only change in 0.3.3 is the daemonset is correct again